### PR TITLE
Added typeDefs and added the additional "conversationTitle" field to the Conversation model

### DIFF
--- a/server/models/Conversation.js
+++ b/server/models/Conversation.js
@@ -20,34 +20,38 @@ const commentSchema = new mongoose.Schema({
 });
 
 const conversationSchema = new Schema({
-    conversationText: {
-      type: String,
-      required: true,
-      minlength: 1,
-      maxlength: 500,
-      trim: true,
-    },
-    expertise: {
-      type: String,
-      required: true
-    },
-    author: {
-      type: Schema.Types.ObjectId,
-      ref: 'User'
-    },
-    listener: {
-      type: Schema.Types.ObjectId,
-      ref: 'User'
-    },
-    comments: [commentSchema],
-    createdAt: {
-      type: Date,
-      default: Date.now,
-    },
-    is_closed: {
-      type: Boolean
-    },
-  });
+  conversationTitle: {
+    type: String,
+    required: true,
+  },
+  conversationText: {
+    type: String,
+    required: true,
+    minlength: 1,
+    maxlength: 500,
+    trim: true,
+  },
+  expertise: {
+    type: String,
+    required: true,
+  },
+  author: {
+    type: Schema.Types.ObjectId,
+    ref: "User",
+  },
+  listener: {
+    type: Schema.Types.ObjectId,
+    ref: "User",
+  },
+  comments: [commentSchema],
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+  is_closed: {
+    type: Boolean,
+  },
+});
 
 const Conversation = model('Conversation', conversationSchema);
 

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -1,20 +1,49 @@
 const typeDefs = `
-  type Profile {
+  type User {
     _id: ID
-    name: String
-    skills: [String]!
+    username: String
+    password: String
+    buddy: ID
+    availability: Boolean
+    role: String
+    expertise: String
+    conversations: [Conversation]!
+  }
+
+  type Conversation {
+    conversationTitle: String
+    conversationText: String
+    expertise: String
+    author: ID
+    listener: ID
+    comments: [Comment]!
+    createdAt: String
+    is_closed: Boolean
+  }
+
+  type Response {
+    commentId: ID
+    comment: String
+    author: String
+    createdAt: String
+  }
+
+  type Auth {
+    token: ID!
+    user: User
   }
 
   type Query {
-    profiles: [Profile]!
-    profile(profileId: ID!): Profile
+    users: [User]
+    user(id: ID!): User
+    conversation(id: ID!): Conversation
   }
 
   type Mutation {
-    addProfile(name: String!): Profile
-    addSkill(profileId: ID!, skill: String!): Profile
-    removeProfile(profileId: ID!): Profile
-    removeSkill(profileId: ID!, skill: String!): Profile
+    addUser(username: String!, password: String!, role: String!, expertise: String): Auth
+    login(email: String!, password: String!): Auth
+    addConversation(conversationTitle: String!, conversationText: String!, expertise: String!): Conversation
+    addComment(conversationId: ID!, comment: String!, author: ID!): Conversation
   }
 `;
 


### PR DESCRIPTION
Changes made in this PR:

1. Added in conversationTitle field to the conversation schema (note that nothing else in the schema was changed, but used "Format Selection" in VSCode so it removed the extra spaces in the schema).
2. Added typeDef:
   - Based on Module 21 MERN - Activity 24, added in "type Auth" as it looks like we may need this when adding the JWT authentication. Can be removed if deemed not required later on.
   - "Availability" is not added to the "addUser" type Mutation as unsure if this will be one of the columns on the sign up page.
   - Line 10 uses "conversations: [Conversation]!"  instead of "conversation: Conversation" as the conversation will end some day and there'll be a new conversation stored with the user and that will be an array instead of an object.
