### PR TITLE
Fixed typo that blocked localhost connection

### DIFF
--- a/server/models/Conversation.js
+++ b/server/models/Conversation.js
@@ -1,6 +1,6 @@
 const { Schema, model, Types } = require('mongoose');
 
-const commentSchema = new mongoose.Schema({
+const commentSchema = new Schema({
   commentId: {
     type: Schema.Types.ObjectId,
     default: () => new Types.ObjectId(),

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,4 +1,4 @@
 const User = require('./User');
-const Conversation = requrie('./Conversation')
+const Conversation = require('./Conversation')
 
 module.exports = { User, Conversation };


### PR DESCRIPTION
Caught two issues when trying to npm run start:

- When requiring Conversation, `require` was misspelled -- Corrected now
- When creating commentSchema `mongoose` was incorrectly added -- Removed now 

```
const Conversation = require('./Conversation')
```

```
const commentSchema = new Schema({
```