### PR TITLE
My Bench: Conditional Rendering 

### DIFF
--- a/client/src/components/Cards.jsx
+++ b/client/src/components/Cards.jsx
@@ -52,23 +52,25 @@ export default function Cards() {
             className="relative overflow-hidden rounded-lg bg-white px-4 pb-12 pt-5 shadow sm:px-6 sm:pt-6"
           >
             <dt>
-              <div className="absolute rounded-md bg-indigo-500 p-3">
+              <div className="absolute rounded-md bg-green-700 bg-opacity-80 p-3">
                 <item.icon className="h-6 w-6 text-white" aria-hidden="true" />
               </div>
-              <h2 className="ml-16 p-2 text-2xl font-semibold text-gray-900">
-                {item.name}
+              <h2 className="ml-16 p-3 text-2xl font-semibold text-gray-900">
+                {/* -------------limit the characters to 30 max------------- */}
+                {item.name.slice(0, 15)}
+                {item.name.length > 15 ? "..." : ""}
               </h2>
             </dt>
-            <dd className="ml-2 m-8 p-1 flex-col items-baseline sm:pb-3">
-              <p id="lookHere" className="text-med font-medium text-gray-900">
+            <dd className="mb-8 p-1 flex-col items-baseline sm:pb-3">
+              <p className="flex justify-center text-med font-medium bg-orange-100 rounded-md text-gray-800">
                 {/* -------------limit the characters to 30 max------------- */}
-                {item.preview.slice(0, 30)}
-                {item.preview.length > 30 ? "..." : ""} 
+                {item.preview.slice(0, 20)}
+                {item.preview.length > 20 ? "..." : ""}
               </p>
               <div className="absolute inset-x-0 bottom-0 bg-gray-50 px-4 py-4 sm:px-6">
                 <div className="text-sm">
                   <p className="mb-2 text-sm font-medium text-gray-500">
-                    Your bench with {item.buddy}
+                    Your sharing this bench with {item.buddy}
                   </p>
                   {/* <a href="#" className="font-medium text-indigo-600 hover:text-indigo-500">
                     View conversation<span className="sr-only"> {item.name} details</span>

--- a/client/src/components/Cards.jsx
+++ b/client/src/components/Cards.jsx
@@ -2,22 +2,14 @@ import React, { useEffect, useState } from "react";
 import { useQuery } from "@apollo/client";
 import { GET_USER_BY_ID } from "../utils/queries";
 import Auth from "../utils/auth";
-import { ArrowDownIcon, ArrowUpIcon } from "@heroicons/react/20/solid";
 import {
-  CursorArrowRaysIcon,
-  EnvelopeOpenIcon,
   ChatBubbleOvalLeftEllipsisIcon,
+  PlusIcon,
 } from "@heroicons/react/24/outline";
-
-// Utility function for conditional class names
-function classNames(...classes) {
-  return classes.filter(Boolean).join(" ");
-}
 
 export default function Cards() {
   const userProfile = Auth.getProfile();
   const userId = userProfile?.data?._id;
-  console.log(userProfile.data.username);
 
   const { data, loading, error } = useQuery(GET_USER_BY_ID, {
     variables: { userId },
@@ -26,7 +18,6 @@ export default function Cards() {
 
   // Extract conversation data if available
   const conversationData = data?.user?.conversation;
-  console.log(conversationData);
 
   if (loading) return <p>Loading conversations...</p>;
   if (error) return <p>Error loading conversations: {error.message}</p>;
@@ -37,37 +28,62 @@ export default function Cards() {
           id: conversationData._id,
           name: conversationData.conversationTitle,
           preview: conversationData.conversationText,
-          buddy: userProfile.data.username, // replace with userProfile.data.buddy once that's ready
+          buddy: userProfile.data.username,
           icon: ChatBubbleOvalLeftEllipsisIcon,
         },
       ]
     : [];
 
+  // Function to handle starting a new conversation
+  const handleNewConversation = () => {
+    // Navigate to new conversation page or component
+    console.log("is this working? YUP! :)");
+  };
+
   return (
     <div>
+                <h2 className="text-xlg font-semibold leading-6 text-gray-900">Your Bench</h2>
       <dl className="mt-5 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+      <div
+          onClick={handleNewConversation}
+          className="cursor-pointer relative overflow-hidden rounded-lg bg-gray-100 px-4 pb-12 shadow sm:px-6 sm:pt-6 hover:bg-orange-200"
+        >
+          <dt>
+            <div className="absolute rounded-md bg-green-700 bg-opacity-80 p-3">
+              <PlusIcon className="h-6 w-6 text-white" aria-hidden="true" />
+            </div>
+            <h2 className="ml-16 p-3 text-2xl font-semibold text-gray-900">
+              Start a New Conversation
+            </h2>
+          </dt>
+          <dd className="mb-8 p-1 flex justify-center items-baseline sm:pb-3">
+            <p className="text-med font-medium text-gray-800">
+              Share your thoughts with a listener.
+            </p>
+          </dd>
+        </div>
         {conversations.map((item) => (
           <div
             key={item.id}
-            className="relative overflow-hidden rounded-lg bg-white px-4 pb-12 pt-5 shadow sm:px-6 sm:pt-6"
+            className="cursor-pointer hover:bg-orange-200 relative overflow-hidden rounded-lg bg-gray-100 px-4 pb-12 shadow sm:px-6 sm:pt-6"
           >
             <dt>
               <div className="absolute rounded-md bg-green-700 bg-opacity-80 p-3">
                 <item.icon className="h-6 w-6 text-white" aria-hidden="true" />
               </div>
               <h2 className="ml-16 p-3 text-2xl font-semibold text-gray-900">
-                {/* -------------limit the characters to 30 max------------- */}
-                {item.name.slice(0, 15)}
-                {item.name.length > 15 ? "..." : ""}
+                {/* -------------limit the characters to 22 max------------- */}
+                {item.name.slice(0, 22)}
+                {item.name.length > 22 ? "..." : ""}
               </h2>
             </dt>
             <dd className="mb-8 p-1 flex-col items-baseline sm:pb-3">
               <p className="flex justify-center text-med font-medium bg-orange-100 rounded-md text-gray-800">
-                {/* -------------limit the characters to 30 max------------- */}
-                {item.preview.slice(0, 20)}
-                {item.preview.length > 20 ? "..." : ""}
+                {/* -------------limit the characters to 33 max------------- */}
+                {item.preview.slice(0, 37)}
+                {item.preview.length > 37 ? "..." : ""}
               </p>
-              <div className="absolute inset-x-0 bottom-0 bg-gray-50 px-4 py-4 sm:px-6">
+              <div className="absolute inset-x-0 bottom-0 px-4 py-4 sm:px-6">
                 <div className="text-sm">
                   <p className="mb-2 text-sm font-medium text-gray-500">
                     Your sharing this bench with {item.buddy}
@@ -80,6 +96,7 @@ export default function Cards() {
             </dd>
           </div>
         ))}
+        
       </dl>
     </div>
   );

--- a/client/src/components/Cards.jsx
+++ b/client/src/components/Cards.jsx
@@ -1,0 +1,84 @@
+import React, { useEffect, useState } from "react";
+import { useQuery } from "@apollo/client";
+import { GET_USER_BY_ID } from "../utils/queries";
+import Auth from "../utils/auth";
+import { ArrowDownIcon, ArrowUpIcon } from "@heroicons/react/20/solid";
+import {
+  CursorArrowRaysIcon,
+  EnvelopeOpenIcon,
+  ChatBubbleOvalLeftEllipsisIcon,
+} from "@heroicons/react/24/outline";
+
+// Utility function for conditional class names
+function classNames(...classes) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export default function Cards() {
+  const userProfile = Auth.getProfile();
+  const userId = userProfile?.data?._id;
+  console.log(userProfile.data.username);
+
+  const { data, loading, error } = useQuery(GET_USER_BY_ID, {
+    variables: { userId },
+    skip: !userId, // Only proceed if userId is available
+  });
+
+  // Extract conversation data if available
+  const conversationData = data?.user?.conversation;
+  console.log(conversationData);
+
+  if (loading) return <p>Loading conversations...</p>;
+  if (error) return <p>Error loading conversations: {error.message}</p>;
+
+  const conversations = conversationData
+    ? [
+        {
+          id: conversationData._id,
+          name: conversationData.conversationTitle,
+          preview: conversationData.conversationText,
+          buddy: userProfile.data.username, // replace with userProfile.data.buddy once that's ready
+          icon: ChatBubbleOvalLeftEllipsisIcon,
+        },
+      ]
+    : [];
+
+  return (
+    <div>
+      <dl className="mt-5 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        {conversations.map((item) => (
+          <div
+            key={item.id}
+            className="relative overflow-hidden rounded-lg bg-white px-4 pb-12 pt-5 shadow sm:px-6 sm:pt-6"
+          >
+            <dt>
+              <div className="absolute rounded-md bg-indigo-500 p-3">
+                <item.icon className="h-6 w-6 text-white" aria-hidden="true" />
+              </div>
+              <h2 className="ml-16 p-2 text-2xl font-semibold text-gray-900">
+                {item.name}
+              </h2>
+            </dt>
+            <dd className="ml-2 m-8 p-1 flex-col items-baseline sm:pb-3">
+              <p id="lookHere" className="text-med font-medium text-gray-900">
+                {/* -------------limit the characters to 30 max------------- */}
+                {item.preview.slice(0, 30)}
+                {item.preview.length > 30 ? "..." : ""} 
+              </p>
+              <div className="absolute inset-x-0 bottom-0 bg-gray-50 px-4 py-4 sm:px-6">
+                <div className="text-sm">
+                  <p className="mb-2 text-sm font-medium text-gray-500">
+                    Your bench with {item.buddy}
+                  </p>
+                  {/* <a href="#" className="font-medium text-indigo-600 hover:text-indigo-500">
+                    View conversation<span className="sr-only"> {item.name} details</span>
+                  </a> */}
+                </div>
+              </div>
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}

--- a/client/src/pages/MyBench.jsx
+++ b/client/src/pages/MyBench.jsx
@@ -29,8 +29,7 @@ export default function MyBench() {
   if (error) return <p>Error: {error.message}</p>;
 
   return (
-    <div className="h-screen">
-            <h3 className="text-xlg font-semibold leading-6 text-gray-900">Your Bench</h3>
+    <div className="h-screen w-screen">
       <div>
         {isLoggedIn && hasConversation ? <Cards /> : <ConversationsForm />}
       </div>

--- a/client/src/pages/MyBench.jsx
+++ b/client/src/pages/MyBench.jsx
@@ -1,37 +1,39 @@
+import React, { useEffect, useState } from 'react';
+import { useQuery } from '@apollo/client';
+import { GET_USER_BY_ID } from '../utils/queries';
+import Auth from '../utils/auth';
 import ConversationsForm from "../components/ConversationsForm";
-import UserConversation from "../components/UserConversation";
-// import { PlusIcon } from "@heroicons/react/20/solid";
-// import ConversationsForm from "../components/ConversationsForm";
-
-function classNames(...classes) {
-  return classes.filter(Boolean).join(" ");
-}
-
-const items = [
-  { id: 1 },
-  // More items...
-];
+import Cards from "../components/Cards";
 
 export default function MyBench() {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [hasConversation, setHasConversation] = useState(false);
+
+  const userProfile = Auth.getProfile();
+  const userId = userProfile?.data?._id; 
+
+  const { loading, error, data } = useQuery(GET_USER_BY_ID, {
+    variables: { userId },
+    skip: !Auth.loggedIn(), // Skip query if not logged in
+    onCompleted: data => {
+      // Set hasConversation based on whether the conversation object exists and has an _id
+      setHasConversation(!!data.user.conversation?._id);
+    }
+  });
+
+  useEffect(() => {
+    setIsLoggedIn(Auth.loggedIn());
+  }, []);
+
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p>Error: {error.message}</p>;
+
   return (
     <div className="h-screen">
-      <ul
-        role="list"
-        className="flex-col w-auto m-auto mt-10 place-content-center space-y-3"
-      >
-        <h2 className="my-10 text-28 font-semibold leading-6 text-gray-900">
-          Your Benches
-        </h2>
-        {items.map((item) => (
-          <li
-            key={item.id}
-            className="overflow-hidden rounded-md bg-white px-6 py-4 shadow"
-          >
-            {/* <UserConversation></UserConversation> */}
-            <ConversationsForm></ConversationsForm>
-          </li>
-        ))}
-      </ul>
+            <h3 className="text-xlg font-semibold leading-6 text-gray-900">Your Bench</h3>
+      <div>
+        {isLoggedIn && hasConversation ? <Cards /> : <ConversationsForm />}
+      </div>
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tech-friends",
+  "name": "soul-bench",
   "version": "1.0.0",
   "description": "",
   "main": "server/server.js",


### PR DESCRIPTION
#Primary changes 

- Added conditional rendering for the My Bench page
     - My Bench will display 'conversationCard' if a conversation already exists
     - Cards.jsx includes logic to dynamically render 'conversationCards' if we can support a user having multiple conversations at once (incl. conversation history)
     - In the same vein, a card is presented to the user to start a new conversation on the My Bench place as a static element 

![image](https://github.com/ae-andre/insights-bench/assets/85869787/10b7e50b-b6e7-4923-b22f-3a4374b63d8a)

- I set up this logic to conditionally render either the Cards OR the ConversationsForm, but it might be worth rethinking the flow since we can use the Start New Convo card instead:

![image](https://github.com/ae-andre/insights-bench/assets/85869787/e98238c8-524e-49f0-b9a3-26d8f1154938)

- For above, I'd recommend a new page for the start new convo form

-------------------
##Minor details / Notes

- Added logic to limit characters shown on cards
- Once the matching logic works, the Cards.jsx can be adjusted to display the buddy's name
- BUG: From /my-bench, the logout button does not redirect away from my-bench, so it causes an error saying the validation token is invalid:

![image](https://github.com/ae-andre/insights-bench/assets/85869787/285f8081-28f3-41f8-a59c-a1ad62d58655)
