### PR TITLE
Bug fixes [FIXED]

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -164,3 +164,17 @@ button {
   height: 100%;
   z-index: -1;
 }
+
+.error-page {
+  height: 100vh;
+  text-align: center;
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+}
+.error-image {
+  height: 100px;
+  margin-bottom: 5px;
+  margin-right: 10px;
+}

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -41,7 +41,7 @@
 body {
     font-family: var(--font-alegreya-sans);
     background-color: var(--med-light);
-    color: var(--medium);
+    color: var(--light);
     margin: 0;
     /* min-width: 320px;
     min-height: 100vh; */
@@ -121,8 +121,18 @@ button {
   
 .app-banner {
   width: 100%;
-  height: 160px;
+  height: 170px;
 }
+
+.about-para {
+  margin-top:15px
+}
+
+.about-sec {
+  width: auto;
+  height: auto;
+}
+
 
 .card-empty {
   padding-top: 35px !important;
@@ -137,7 +147,8 @@ button {
 }
 
 .preview-text {
-  padding: 10px 0px 10px 0px !important;
+  padding: 10px 10px 10px 10px !important;
+  text-align: center;
 }
 
 .input-option {
@@ -146,4 +157,10 @@ button {
 
 .private-submit:hover {
   background-color: var(--dark);
+}
+
+.about-picture {
+  width: 100%;
+  height: 100%;
+  z-index: -1;
 }

--- a/client/src/components/Cards.jsx
+++ b/client/src/components/Cards.jsx
@@ -44,7 +44,7 @@ export default function Cards() {
         id: conversationData._id,
         name: conversationData.conversationTitle,
         preview: conversationData.conversationText,
-        buddy: user.buddy.username, // ------EDIT ONCE buddy is available-------
+        buddy: user.buddy.username, 
         icon: ChatBubbleOvalLeftEllipsisIcon,
       },
     ]

--- a/client/src/components/Cards.jsx
+++ b/client/src/components/Cards.jsx
@@ -28,6 +28,7 @@ export default function Cards() {
   if (error) return <p>Error: {error.message}</p>;
 
   const user = data?.user;
+  console.log(user)
 
   if (isViewingConversation) {
     return <UserConversation onClose={() => setIsViewingConversation(false)} />;
@@ -43,7 +44,7 @@ export default function Cards() {
         id: conversationData._id,
         name: conversationData.conversationTitle,
         preview: conversationData.conversationText,
-        buddy: "your buddy", // ------EDIT ONCE buddy is available-------
+        buddy: user.buddy.username, // ------EDIT ONCE buddy is available-------
         icon: ChatBubbleOvalLeftEllipsisIcon,
       },
     ]

--- a/client/src/components/Cards.jsx
+++ b/client/src/components/Cards.jsx
@@ -84,7 +84,7 @@ export default function Cards() {
                 {item.name.length > 22 ? "..." : ""}
               </h2>
             </dt>
-            <dd className="mb-8 p-1 flex-col items-baseline sm:pb-3">
+            <dd className="mb-2 p-1 flex-col items-baseline sm:pb-3">
               <p className="flex justify-center text-med font-medium bg-white rounded-md text-gray-800 preview-text">
                 {/* -------------limit the characters to 33 max------------- */}
                 {item.preview.slice(0, 37)}

--- a/client/src/components/Conversation.css
+++ b/client/src/components/Conversation.css
@@ -115,10 +115,11 @@
 }*/
 
   .comment-submit-btn {
-    background-color: var(--med-light) !important; /* Important to override Bootstrap */
-    color: var(--dark) !important; 
-    border: 1px solid var(--dark) !important; 
+    background-color: var(--med-dark) !important; /* Important to override Bootstrap */
+    color: var(--light) !important; 
+    border: 1px solid var(--med-dark) !important; 
     margin-bottom: 20px;
+    margin-right: 10px;
 
 }
 
@@ -135,17 +136,19 @@
 }
 
 .end-convo-btn {
-  background-color: white !important; /* Important to override Bootstrap */
-  color: red !important; 
-  border: 1px solid var(--dark) !important; 
-  margin-bottom: 20px;
-
+  background-color: var(--med-dark) !important; /* Important to override Bootstrap */
+  color: var(--light) !important; 
+  border: 1px solid var(--med-dark) !important; 
+  margin-bottom: 21px;
+  margin-left: 10px;
+  font-family: var(--font-standard);
+  padding: 6px 12px;
 }
 
 .end-convo-btn:hover {
-  background-color: var(--med-dark) !important; 
-  color: var(--med-light) !important; 
-  border: 1px solid var(--med-light) !important; 
+  background-color:red!important; 
+  color: var(--light) !important; 
+  border: 1px solid red !important; 
 } 
 
 .end-convo-btn:active {

--- a/client/src/components/Conversation.css
+++ b/client/src/components/Conversation.css
@@ -7,11 +7,12 @@
   }
   
   .conversation-title {  
-    margin: 20px;
-    font-size: 1.8rem;
+    margin: auto;
+    margin-bottom: 20px;
+    font-size: 2rem;
     font-family: var(--font-headings);
     word-spacing: 7px;
-    text-align: left; 
+    text-align: center; 
     color: var(--dark);
   }
 
@@ -27,7 +28,7 @@
     align-self: center;
     color: var(--dark);
     border-radius: 10px;
-    box-shadow: 0px 2px 4px; 
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.3);
   }
   
   .conversation-text {
@@ -52,7 +53,8 @@
     flex-direction: column;
     align-self: center;
     padding: 10px;
-    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.8);
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.3);
+    /* border: 1px solid var(--med-dark); */
     border-radius: 10px;  
     background-color: var(--med-light);
   }
@@ -68,7 +70,7 @@
     /* overflow-y: auto; */
     margin-bottom: 20px;
     padding: 10px;
-    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.3);
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
     border-radius: 5px;
     background-color: var(--light);
   }
@@ -103,9 +105,8 @@
     margin-bottom: 20px;
     padding: 10px;
     border-radius: 2%;
-    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.5);
-    border: none !important;
-    border: 1px solid transparent !important;
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
+    border: 1px solid var(--med-dark) !important;
   }
 
   /* Can't seem to override this bootstrap styling whatever I do
@@ -125,7 +126,7 @@
 
 .comment-submit-btn:hover {
     background-color: var(--dark) !important; 
-    color: var(--med-light) !important; 
+    color: var(--light) !important; 
     border: 1px solid var(--med-light) !important; 
 } 
 

--- a/client/src/components/Conversation.css
+++ b/client/src/components/Conversation.css
@@ -65,9 +65,17 @@
     margin: 10px, 10px, 0px,;
   }
   
-  .comment {
+  .my-comment {
     /* max-height: 100px;  */
     /* overflow-y: auto; */
+    margin-bottom: 20px;
+    padding: 10px;
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
+    border-radius: 5px;
+    background-color: rgb(254 252 232);
+  }
+
+  .other-comment {
     margin-bottom: 20px;
     padding: 10px;
     box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
@@ -75,7 +83,7 @@
     background-color: var(--light);
   }
   
-  .comment p {
+  .my-comment p, .other-comment p {
     padding: 5px;
     margin: 5px;
   }

--- a/client/src/components/Conversation.jsx
+++ b/client/src/components/Conversation.jsx
@@ -115,7 +115,7 @@ const Conversation = ({ onClose }) => {
       <div className="comment-container">
         <div className="comment-list">
           {fetchedConversation.comments.map((comment, index) => (
-            <div key={index} className="comment">
+            <div key={index} className="other-comment">
               <p className="comment-text">{comment.comment}</p>
               <p className="comment-attribution"><span className="bolded">{comment.username}</span> <span className="bolded">{comment.createdAt}</span></p>
             </div>

--- a/client/src/components/ConversationsForm.jsx
+++ b/client/src/components/ConversationsForm.jsx
@@ -3,6 +3,8 @@ import { Link } from "react-router-dom";
 import { useMutation } from '@apollo/client';
 import { ADD_CONVERSATION, FIND_BUDDY, DELETE_CONVERSATION } from '../utils/mutations';
 import Auth from '../utils/auth';
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 import UserConversation from './UserConversation';
 
 const ConversationsForm = (props) => {
@@ -26,6 +28,18 @@ const ConversationsForm = (props) => {
 
   const handleFormSubmit = async (event) => {
     event.preventDefault();
+
+    // Character limit for conversation title
+    if (convoForm.conversationTitle.length > 50) {
+      toast.info('Conversation title must be 50 characters or less.');
+      return;
+    }
+
+    // Character limit for conversation text
+    if (convoForm.conversationText.length > 500) {
+      toast.info('Details must be 500 characters or less.');
+      return;
+    }
 
     try {
       const { data } = await addConversation({
@@ -71,6 +85,21 @@ const ConversationsForm = (props) => {
 
   return (
     <>
+      <ToastContainer
+        position="top-center"
+        autoClose={1500}
+        hideProgressBar={true}
+        newestOnTop={false}
+        closeOnClick
+        rtl={false}
+        pauseOnFocusLoss
+        draggable
+        pauseOnHover
+        style={{
+          '--toastify-icon-color-info': '#55828b', 
+          '--toastify-color-progress-info': '#55828b', 
+        }} 
+      />
       {!conversationStarted && !haveBuddy ? (
       <div className="flex min-h-full flex-1 flex-col justify-center px-6 pb-10 lg:px-8">
         <div className="sm:mx-auto sm:w-full sm:max-w-sm">
@@ -91,6 +120,7 @@ const ConversationsForm = (props) => {
                 <select
                   id="expertise"
                   name="expertise"
+                  required
                   className="input-option bg-gray-50 border border-gray-300 text-gray-800 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
                   value={convoForm.expertise}
                   onChange={handleChange}
@@ -142,6 +172,7 @@ const ConversationsForm = (props) => {
                   rows={4}
                   name="conversationText"
                   id="conversationText"
+                  required
                   placeholder="  Your story goes here.."
                   value={convoForm.conversationText}
                   onChange={handleChange}

--- a/client/src/components/ConversationsForm.jsx
+++ b/client/src/components/ConversationsForm.jsx
@@ -74,7 +74,7 @@ const ConversationsForm = (props) => {
       {!conversationStarted && !haveBuddy ? (
       <div className="flex min-h-full flex-1 flex-col justify-center px-6 pb-10 lg:px-8">
         <div className="sm:mx-auto sm:w-full sm:max-w-sm">
-          <h2 className=" text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">
+          <h2 className=" text-center text-3xl font-bold leading-9 tracking-tight text-gray-900">
           Let's put things to bench
           </h2>
         </div>

--- a/client/src/components/ConversationsForm.jsx
+++ b/client/src/components/ConversationsForm.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useMutation } from '@apollo/client';
 import { ADD_CONVERSATION, FIND_BUDDY, DELETE_CONVERSATION } from '../utils/mutations';
 import Auth from '../utils/auth';
@@ -7,11 +7,21 @@ import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import UserConversation from './UserConversation';
 
-const ConversationsForm = (props) => {
+const ConversationsForm = (propms, action) => {
+
+  const navigate = useNavigate(); // Initialize the navigate function using the useNavigate hook
+    
+  //Define handleNavigate function to navigate to the specified URL
+  const handleNavigation = (url) => {
+    
+      navigate(url); // Use the navigate function to navigate to the specified URL
+      window.location.reload();
+  };
 
   const [convoForm, setConvoForm] = useState({ expertise: '', conversationTitle: '', conversationText: ''})
   const [haveBuddy, setHaveBuddy] = useState(false)
   const [conversationStarted, setConversationStarted] = useState(false); 
+  const [failedMatch, setFailedMatch] = useState(false)
   
   const [addConversation, { error }] = useMutation(ADD_CONVERSATION)
   const [findBuddy] = useMutation(FIND_BUDDY)
@@ -73,6 +83,7 @@ const ConversationsForm = (props) => {
         }});
         setHaveBuddy(false);
         setConversationStarted(false);
+        setFailedMatch(true);
         setConvoForm({ expertise: '', conversationTitle: '', conversationText: '' });
       } else {
         setHaveBuddy(true);
@@ -100,7 +111,33 @@ const ConversationsForm = (props) => {
           '--toastify-color-progress-info': '#55828b', 
         }} 
       />
-      {!conversationStarted && !haveBuddy ? (
+      {failedMatch ? (
+        <div className="fixed inset-0 z-50 overflow-auto bg-black bg-opacity-50 flex justify-center items-center">
+          <div className="modal-card bg-white rounded-lg p-8">
+            <div className="text-center">
+              <h2 className="text-2xl font-bold mb-0">Sorry!</h2>
+              <p>We apologize for the inconvenience, but it seems our listeners are currently experiencing a high volume of requests, 
+                making it difficult to find an available match at the moment. However, why not take this opportunity to explore the 
+                Pavilion? It's a great place to while waiting. We appreciate your patience and understanding,
+                 and we'll do our best to connect you as soon as possible.</p>
+            </div>
+            <div className="button-and-p-container flex justify-center mt-6 space-y-4 flex-col md:flex-row md:space-x-8">
+              <div id="button-and-p-column-pavilion" className="button-and-p-column flex flex-col items-center">
+                <button id="pavilion-button" className="button btn btn-secondary" onClick={() => handleNavigation('/')}>Pavilion</button>
+                <p className="text-sm text-gray-500">(public conversation)</p>
+              </div>
+              <div id="button-and-p-column-my-bench" className="button-and-p-column flex flex-col items-center">
+                <button id="my-bench-button" className="button btn btn-primary" onClick={() => handleNavigation('/my-bench')}>MyBench</button>
+                <p className="text-sm text-gray-500">(private conversation)</p>
+              </div>
+              <div id="button-and-p-column-playground" className="button-and-p-column flex flex-col items-center">
+                <button id="playground-button" className="button btn btn-primary" onClick={() => handleNavigation('/resources')}>Playground</button>
+                <p className="text-sm text-gray-500">(resources page)</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : !conversationStarted && !haveBuddy ? (
       <div className="flex min-h-full flex-1 flex-col justify-center px-6 pb-10 lg:px-8">
         <div className="sm:mx-auto sm:w-full sm:max-w-sm">
           <h2 className="text-center text-3xl font-bold leading-9 tracking-tight text-gray-900">

--- a/client/src/components/ConversationsForm.jsx
+++ b/client/src/components/ConversationsForm.jsx
@@ -74,7 +74,7 @@ const ConversationsForm = (props) => {
       {!conversationStarted && !haveBuddy ? (
       <div className="flex min-h-full flex-1 flex-col justify-center px-6 pb-10 lg:px-8">
         <div className="sm:mx-auto sm:w-full sm:max-w-sm">
-          <h2 className=" text-center text-3xl font-bold leading-9 tracking-tight text-gray-900">
+          <h2 className="text-center text-3xl font-bold leading-9 tracking-tight text-gray-900">
           Let's put things to bench
           </h2>
         </div>

--- a/client/src/components/ConversationsForm.jsx
+++ b/client/src/components/ConversationsForm.jsx
@@ -75,7 +75,7 @@ const ConversationsForm = (props) => {
       <div className="flex min-h-full flex-1 flex-col justify-center px-6 pb-10 lg:px-8">
         <div className="sm:mx-auto sm:w-full sm:max-w-sm">
           <h2 className="text-center text-3xl font-bold leading-9 tracking-tight text-gray-900">
-          Let's put things to bench
+          Your bench awaits...
           </h2>
         </div>
 

--- a/client/src/components/ConversationsForm.jsx
+++ b/client/src/components/ConversationsForm.jsx
@@ -124,8 +124,9 @@ const ConversationsForm = (props) => {
                   value={convoForm.conversationTitle}
                   onChange={handleChange}
                   placeholder="  Topic of the discussion"
-                  className="input-option block w-full rounded-md border-1 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+                  className="pl-2 input-option block w-full rounded-md border-1 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
                 />
+                <span className="pt-2 inset-y-0 right-0 pr-2 flex items-center text-sm text-gray-400">{convoForm.conversationTitle.length}/50</span>
               </div>
             </div>
 
@@ -144,8 +145,9 @@ const ConversationsForm = (props) => {
                   placeholder="  Your story goes here.."
                   value={convoForm.conversationText}
                   onChange={handleChange}
-                  className="input-option block w-full rounded-md border-1 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+                  className="mb-0 input-option block w-full rounded-md border-1 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
                 />
+                <span className="pt-2 inset-y-0 right-0 pr-2 flex items-center text-sm text-gray-400">{convoForm.conversationText.length}/500</span>
               </div>
             </div>
 

--- a/client/src/components/ConversationsFormPublic.jsx
+++ b/client/src/components/ConversationsFormPublic.jsx
@@ -86,7 +86,7 @@ const ConversationsFormPublic = (props) => {
       ) : (
         <div className="flex min-h-full flex-1 flex-col justify-center px-6 pb-10 lg:px-8">
           <div className="sm:mx-auto sm:w-full sm:max-w-sm">
-            <h2 className="text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">
+            <h2 className="text-center mb-0 text-2xl font-bold leading-9 tracking-tight text-gray-900">
               Start a Conversation in the Pavilion
             </h2>
           </div>
@@ -157,8 +157,9 @@ const ConversationsFormPublic = (props) => {
                   placeholder="  Your story goes here.."
                   value={convoForm.conversationText}
                   onChange={handleChange}
-                  className="block w-full rounded-md border-1 input-option py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+                  className="block mb-0 w-full rounded-md border-1 input-option py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
                 />
+                <span className="pt-2 inset-y-0 right-0 pr-2 flex items-center text-sm text-gray-400">{convoForm.conversationText.length}/500</span>
               </div>
             </div>
 

--- a/client/src/components/ConversationsFormPublic.jsx
+++ b/client/src/components/ConversationsFormPublic.jsx
@@ -9,7 +9,6 @@ import 'react-toastify/dist/ReactToastify.css';
 import './ConversationsFormPublic.css'
 import Conversation from './Conversation';
 
-
 const ConversationsFormPublic = (props) => {
 
   const [convoForm, setConvoForm] = useState({ expertise: '', conversationTitle: '', conversationText: ''})
@@ -105,6 +104,7 @@ const ConversationsFormPublic = (props) => {
                 <select
                   id="expertise"
                   name="expertise"
+                  required
                   className="bg-gray-50 border-1 input-option text-gray-800 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
                   value={convoForm.expertise}
                   onChange={handleChange}
@@ -156,6 +156,7 @@ const ConversationsFormPublic = (props) => {
                   rows={4}
                   name="conversationText"
                   id="conversationText"
+                  required
                   placeholder="  Your story goes here.."
                   value={convoForm.conversationText}
                   onChange={handleChange}

--- a/client/src/components/ConversationsFormPublic.jsx
+++ b/client/src/components/ConversationsFormPublic.jsx
@@ -42,6 +42,8 @@ const ConversationsFormPublic = (props) => {
       return;
     }
 
+    // If not area of help is choosen --> toast
+
     try {
       const { data } = await addPublicConversation({
         variables: {
@@ -86,7 +88,7 @@ const ConversationsFormPublic = (props) => {
       ) : (
         <div className="flex min-h-full flex-1 flex-col justify-center px-6 pb-10 lg:px-8">
           <div className="sm:mx-auto sm:w-full sm:max-w-sm">
-            <h2 className="text-center mb-0 text-2xl font-bold leading-9 tracking-tight text-gray-900">
+            <h2 className="text-center mb-0 text-3xl font-bold leading-9 tracking-tight text-gray-900">
               Start a Conversation in the Pavilion
             </h2>
           </div>

--- a/client/src/components/ConversationsList.jsx
+++ b/client/src/components/ConversationsList.jsx
@@ -3,6 +3,10 @@ import { Link } from 'react-router-dom';
 import './ConversationsList.css';
 
 const ConversationsList = ({ conversations, expertise, onConversationClick }) => {
+  const handleClick = (conversationId) => {
+    onConversationClick(conversationId);
+    window.scrollTo({ top: 5, behavior: 'smooth' });
+  }
   console.log('Received expertise:', expertise);
   console.log('Conversations:', conversations);
   
@@ -15,8 +19,9 @@ const ConversationsList = ({ conversations, expertise, onConversationClick }) =>
             <li key={conversation._id} className="list-group-item d-flex justify-content-between align-items-start">
               <div className="ms-2 me-auto">
                 {/* Use Link component for navigation to a new conversation_id endpoint whenever a particular conversation.title is clicked */}
-                <Link to={`/conversation/${conversation._id}`}
-                onClick={() => onConversationClick(conversation._id)}
+                <Link 
+                  to={`/conversation/${conversation._id}`}
+                  onClick={() => handleClick(conversation._id)}
                 >
                   <div className="fw-bold">{conversation.conversationTitle}</div>
                 </Link>

--- a/client/src/components/Header/index.jsx
+++ b/client/src/components/Header/index.jsx
@@ -4,7 +4,7 @@ import './Header.css';
 
 const Header = () => {
   return (
-    <header className="text-dark mb-4 py-3 display-flex align-center" id="header-top">
+    <header className="text-dark mb-4 py-3 display-flex align-center" id="conversation">
       <div className="container flex-column justify-space-between-lg justify-center align-center text-center">
         <Link className="text-dark" to="/">
         </Link>

--- a/client/src/components/Header/index.jsx
+++ b/client/src/components/Header/index.jsx
@@ -4,7 +4,7 @@ import './Header.css';
 
 const Header = () => {
   return (
-    <header className="text-dark mb-4 py-3 display-flex align-center">
+    <header className="text-dark mb-4 py-3 display-flex align-center" id="header-top">
       <div className="container flex-column justify-space-between-lg justify-center align-center text-center">
         <Link className="text-dark" to="/">
         </Link>

--- a/client/src/components/ListenerSignup/index.jsx
+++ b/client/src/components/ListenerSignup/index.jsx
@@ -76,7 +76,7 @@ const signUpListener = () => {
               <ModalAfterLogin onClose={() => setShowModal(false)} action="signup" />
             ) : (
               <div className="sm:mx-auto sm:w-full sm:max-w-sm">
-                <h2 className="text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">
+                <h2 className="text-center text-3xl font-bold leading-9 tracking-tight text-gray-900">
                   Become a Listener Today
                 </h2>
                 <div>
@@ -175,7 +175,7 @@ const signUpListener = () => {
             </fieldset>
 
             <div>
-                <h1 className="font-bold text-sm">Disclaimer:</h1>
+                <h1 className="font-bolder text-sm">Disclaimer:</h1>
                 <p className="text-xs">As a listener on this platform, it's important to understand that while we're here to offer support and lend an empathetic ear,
                     we are not trained therapists or counselors. Our intention is to provide a safe space for others to express themselves. However, we may not have the expertise to offer professional advice or solutions 
                     to complex issues.

--- a/client/src/components/ModalAfterLogin.css
+++ b/client/src/components/ModalAfterLogin.css
@@ -31,7 +31,7 @@
 
 .button:hover {
     background-color: var(--med-dark);
-    color: var(--light);
+    color: var(--light) !important;
 }
 
 .button:active {

--- a/client/src/components/ModalAfterLogin.jsx
+++ b/client/src/components/ModalAfterLogin.jsx
@@ -14,7 +14,7 @@ const ModalAfterLogin = ({ onClose, action }) => {
     <div className="fixed inset-0 z-50 overflow-auto bg-black bg-opacity-50 flex justify-center items-center">
       <div className="modal-card bg-white rounded-lg p-8">
         <div className="text-center">
-          <h2 className="text-2xl font-bold mb-4">Success!</h2>
+          <h2 className="text-2xl font-bold mb-0">Success!</h2>
           {action === 'login' ? (
               <p>Your login was successful. <br />Where would you like to go now?</p>
           ) : (

--- a/client/src/components/Navbar/index.jsx
+++ b/client/src/components/Navbar/index.jsx
@@ -54,6 +54,7 @@ function Nav() {
                 <div className="flex flex-shrink-0 items-center">
                   <Link
                     to="/"
+                    reloadDocument
                     className="h-8 w-auto"
                     style={{ width: "102px", height: "98%", cursor: "pointer" }}
                   >

--- a/client/src/components/SharerSignup/index.jsx
+++ b/client/src/components/SharerSignup/index.jsx
@@ -53,7 +53,7 @@ const signUpSharer = (props) => {
           <ModalAfterLogin onClose={() => setShowModal(false)} action="signup" />
         ) : (
           <div className="sm:mx-auto sm:w-full sm:max-w-sm sharer-container">
-            <h2 className="text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">
+            <h2 className="text-center text-3xl font-bold leading-9 tracking-tight text-gray-900">
               Become a Sharer Today
             </h2>
             <div className="col image-column-left">

--- a/client/src/components/UserConversation.jsx
+++ b/client/src/components/UserConversation.jsx
@@ -113,10 +113,17 @@ const UserConversation = ({ onClose }) => {
       <div className="comment-container">
         <div className="comment-list">
           {fetchedConversation.comments.map((comment, index) => (
-            <div key={index} className="comment">
-              <p className="comment-text">{comment.comment}</p>
-              <p className="comment-attribution"><span className="bolded">{comment.username}</span> <span className="bolded">{comment.createdAt}</span></p>
-            </div>
+            comment.username === userData.user.username ? (
+              <div key={index} className="my-comment">
+                <p className="comment-text">{comment.comment}</p>
+                <p className="comment-attribution"><span className="bolded">{comment.username}</span> <span className="bolded">{comment.createdAt}</span></p>
+              </div>
+            ) : (
+              <div key={index} className="other-comment">
+                <p className="comment-text">{comment.comment}</p>
+                <p className="comment-attribution"><span className="bolded">{comment.username}</span> <span className="bolded">{comment.createdAt}</span></p>
+              </div>
+            )
           ))}
         </div>
       </div>

--- a/client/src/components/UserConversation.jsx
+++ b/client/src/components/UserConversation.jsx
@@ -100,7 +100,7 @@ const UserConversation = ({ onClose }) => {
       <div className="conversation-text-and-attribution">
         <div className="conversation-text">{fetchedConversation.conversationText}</div>
         <p className="conversation-attribution">
-          Conversation opened by <span>{fetchedConversation.username}</span> <br /> <span>{fetchedConversation.createdAt}</span>
+          Conversation opened by <span><b>{fetchedConversation.username}</b></span> <br /> <span>{fetchedConversation.createdAt}</span>
         </p>
       </div>
       <div className="comment-container">
@@ -108,7 +108,7 @@ const UserConversation = ({ onClose }) => {
           {fetchedConversation.comments.map((comment, index) => (
             <div key={index} className="comment">
               <p className="comment-text">{comment.comment}</p>
-              <p className="comment-attribution"><span>{comment.username}</span> <span>{comment.createdAt}</span></p>
+              <p className="comment-attribution"><span className="bolded">{comment.username}</span> <span className="bolded">{comment.createdAt}</span></p>
             </div>
           ))}
         </div>

--- a/client/src/components/UserConversation.jsx
+++ b/client/src/components/UserConversation.jsx
@@ -20,7 +20,8 @@ const UserConversation = ({ onClose }) => {
   const {
     loading: userLoading,
     error: userError,
-    data: userData,
+    data: userData, 
+    refetch: refetchUser,
   } = useQuery(GET_USER_BY_ID, {
     variables: { userId },
     skip: !userId,
@@ -30,7 +31,12 @@ const UserConversation = ({ onClose }) => {
   console.log(userData)
 
 
-  const { loading, error, data, refetch } = useQuery(GET_CONVERSATION_BY_ID, {
+  const { 
+    loading, 
+    error, 
+    data, 
+    refetch: refetchConversation,
+   } = useQuery(GET_CONVERSATION_BY_ID, {
     skip: !conversationId,
     variables: { conversationId },
   });
@@ -40,10 +46,11 @@ const UserConversation = ({ onClose }) => {
   const [deleteConversation] = useMutation(DELETE_CONVERSATION);
 
   useEffect(() => {
-    if (conversationId) {
-      refetch();
+    if (!conversationId) {
+      refetchUser();
+      refetchConversation;
     }
-  }, [conversationId, refetch]);
+  }, [conversationId, refetchUser, refetchConversation]);
 
   const handleChange = (event) => {
     setCommentText(event.target.value);

--- a/client/src/components/UserConversation.jsx
+++ b/client/src/components/UserConversation.jsx
@@ -107,7 +107,7 @@ const UserConversation = ({ onClose }) => {
       <div className="conversation-text-and-attribution">
         <div className="conversation-text">{fetchedConversation.conversationText}</div>
         <p className="conversation-attribution">
-          Conversation opened by <span><b>{fetchedConversation.username}</b></span> <br /> <span>{fetchedConversation.createdAt}</span>
+          Conversation with <span><b>{userData.user.buddy.username}</b></span> <br /> <span>{fetchedConversation.createdAt}</span>
         </p>
       </div>
       <div className="comment-container">

--- a/client/src/pages/Error.jsx
+++ b/client/src/pages/Error.jsx
@@ -5,7 +5,8 @@ export default function ErrorPage() {
   console.error(error);
 
   return (
-    <div id="error-page">
+    <div className="error-page" id="error-page">
+      <img className="error-image" src="https://res.cloudinary.com/dsdsdv6zj/image/upload/v1711330347/error_wdhf7x.png"></img>
       <h1>Oops!</h1>
       <p>Sorry, an unexpected error has occurred.</p>
       <p>

--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -23,7 +23,7 @@ p {
 h3 {
     color: var(--light);
     padding-top: 10px;
-    font-size: 1.5rem;
+    font-size: 1.7rem;
     margin-bottom: 15px;
 }
 
@@ -81,7 +81,7 @@ h3 {
 }
 
 #start-public-conversation-btn:hover {
-    color: var(--med-light);
+    color: var(--light);
     background-color: var(--dark);
     border-color: var(--dark);
 }
@@ -114,7 +114,14 @@ h3 {
 .goto-pavilion{
     background-color: var(--med-dark);
     color: var(--light);
+    font-size: larger;
+    font-family: var(--font-standard);
+}
 
+.goto-pavilion:hover{
+    background-color: var(--dark);
+    color: var(--light);
+    font-family: var(--font-standard);
 }
 
 .homepage-img{

--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -50,7 +50,7 @@ h3 {
     height: 90%; 
 }
 
-#welcome-to-pavilion-title {
+#welcome-to-pavilion {
     font-size: 2.7rem;
     margin-top: 20px;
     margin-bottom: 0px !important;

--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -78,6 +78,7 @@ h3 {
     padding: 10px;
     color: var(--med-dark);
     background-color: var(--light);
+    font-family: var(--font-standard);
 }
 
 #start-public-conversation-btn:hover {

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -113,7 +113,7 @@ const Home = () => {
                 <p id="welcome-to-pavilion-blurb">There are always ongoing conversations here in the pavilion. Click to view. Login to participate. Logged in users can start a new public conversation here or a private conversation on their own bench at login. </p>
               </div>
               <div className="col button-column-right">
-                <button id="start-public-conversation-btn" onClick={handleStartPublicConversation}>+ New Public Conversation</button>  
+              <a href ="#header-top"><button id="start-public-conversation-btn" onClick={handleStartPublicConversation}>+ New Public Conversation</button></a>
               </div>
             </div>
           </div>

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -113,7 +113,7 @@ const Home = () => {
                 <p id="welcome-to-pavilion-blurb">There are always ongoing conversations here in the pavilion. Click to view. Login to participate. Logged in users can start a new public conversation here or a private conversation on their own bench at login. </p>
               </div>
               <div className="col button-column-right">
-              <a href ="#header-top"><button id="start-public-conversation-btn" onClick={handleStartPublicConversation}>+ New Public Conversation</button></a>
+              <a href ="#conversation"><button id="start-public-conversation-btn" onClick={handleStartPublicConversation}>+ New Public Conversation</button></a>
               </div>
             </div>
           </div>

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -49,6 +49,7 @@ const Home = () => {
     console.log('Clicked conversation ID:', conversationId);
     localStorage.setItem('selectedConversationId', conversationId);
     setSelectedConversationId(conversationId);
+    setIsStartingPublicConversation(false)
     console.log('Selected conversation ID after update:', selectedConversationId);
   };
 

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -94,7 +94,7 @@ const Home = () => {
                             life's perplexities with anonymous others.
                             </p>
                             <div className="">
-                                <a href ="#welcome-to-pavilion-title"><button className="goto-pavilion">Click here to checkout the pavilion</button></a>
+                                <a href ="#welcome-to-pavilion"><button className="goto-pavilion">Wander around the pavilion</button></a>
                                 <img className="homepage-img" src='https://res.cloudinary.com/dsdsdv6zj/image/upload/v1711305274/homepage_sno7jy.png' alt="Line drawing of a street light, bench, and tree" />
                             </div>
                         </div>
@@ -103,7 +103,7 @@ const Home = () => {
             )}
         </div>
         <div className="row public-conversations-section">
-          <h3 id="welcome-to-pavilion-title">Grab a bench in the pavilion</h3>
+          <h3 id="welcome-to-pavilion">Grab a bench in the pavilion</h3>
           <div className="public-conversations-header-section">
             <div className="row">
               {/* <div className="col image-column-left">

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -57,7 +57,7 @@ const Login = (props) => {
           <ModalAfterLogin onClose={() => setShowModal(false)} />
         ) : (
           <div className="sm:mx-auto sm:w-full sm:max-w-sm get-started">
-              <h2 className="text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">
+              <h2 className="text-center text-3xl font-bold leading-9 tracking-tight text-gray-900">
                 Welcome Back!
               </h2>
               <div className="col image-column-left">

--- a/client/src/pages/Resources.css
+++ b/client/src/pages/Resources.css
@@ -99,6 +99,7 @@ a.assessment-links {
     display: inline-block;
     font-size: 1.1rem;
     width: 100%;   
+    font-family: var(--font-standard);
 }
 
 a.assessment-links:hover {

--- a/client/src/pages/Role.css
+++ b/client/src/pages/Role.css
@@ -3,7 +3,7 @@
     align-items: center;
 }
 
-.title {
+.role-title {
     color: black;
     margin-bottom: 20px;
 }
@@ -11,7 +11,6 @@
 .sharer-card-body {
     color: var(--dark);
     margin-bottom: 20px;
-
 }
 
 .listener-card-body {
@@ -73,4 +72,8 @@
     height: 50px;
     margin: auto;
     margin-top: 20px;
+}
+
+.description-text {
+    font-size: 1rem !important;
 }

--- a/client/src/pages/Role.jsx
+++ b/client/src/pages/Role.jsx
@@ -43,14 +43,14 @@ const RoleSelection = () => {
                 ) : (
                     <div className="bg-white shadow sm:rounded-lg">
                         <div className="overall-card px-4 py-4 sm:p-6 text-center">
-                            <h3 className="title text-2xl font-semibold leading-6 text-gray-900 mb-0">Choose a seat on the bench!</h3>
+                            <h3 className="role-title text-3xl font-semibold leading-6 text-gray-900 mb-0">Choose a seat on the bench!</h3>
                             <br />
                             <div className="grid grid-cols-2 gap-4">
                                 <div className="sharer-card-body p-4 text-sm mt-2 max-w-xs border-r">
                                     <div>
                                         <img className="sharer-image" src="https://res.cloudinary.com/dsdsdv6zj/image/upload/v1711238290/sharer_g9dvcp.png" alt="simple line drawing of a pavilion with perimeter bench seating" />
                                     </div>
-                                    <p className="sharer-description mb-7">
+                                    <p className="sharer-description mb-7 description-text">
                                         Express thoughts, experiences, and emotions in a safe and supportive environment. 
                                         By sharing, individuals have the opportunity to be heard, validated, and understood by others in the community. Sharing can be a 
                                         powerful tool for self-expression and personal growth, but it's crucial to prioritize mental health and seek professional help when needed.
@@ -70,7 +70,7 @@ const RoleSelection = () => {
                                     <div>
                                         <img className="listener-image" src="https://res.cloudinary.com/dsdsdv6zj/image/upload/v1711238289/listener_ou6luo.png" alt="simple line drawing of a pavilion with perimeter bench seating" />
                                     </div>
-                                    <p className="listener-description mt-1/2">
+                                    <p className="listener-description mt-1/2 description-text">
                                         Provide empathetic and nonjudgmental support to those who choose to share their thoughts and experiences
                                         . Listeners offer their time and attention to actively engage with the sharer, demonstrating care and understanding. By actively 
                                         listening and offering support, listeners fosters a sense of community and connection within the platform.

--- a/server/config/connection.js
+++ b/server/config/connection.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
+require('dotenv').config();
 
-mongoose.connect(process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017/soul-bench');
+mongoose.connect(process.env.MONGODB_URI || process.env.DB_NAME );
 
 module.exports = mongoose.connection;

--- a/server/utils/auth.js
+++ b/server/utils/auth.js
@@ -1,7 +1,8 @@
 const { GraphQLError } = require('graphql');
 const jwt = require('jsonwebtoken');
+require('dotenv').config(); 
 
-const secret = 'supersecretgroup3';
+const secret = process.env.SESSION_SECRET;
 const expiration = '2h';
 
 module.exports = {


### PR DESCRIPTION
Current FIxes:

- Added `.env` file
- Added textarea padding and char count for PRIVATE CONVO FORM
![Screenshot 2024-03-24 at 11 08 47 PM](https://github.com/ae-andre/insights-bench/assets/56553374/22393b4c-7205-483b-880e-fc4006dd794b)
- When "+ new public conversation" is clicked, it anchors it to the header so the public form shows
- When user clicks on public conversation, it will automatically scroll to the top to display the conversation
- Changed PRIVATE convo form text to: "Your bench awaits..."
- When logo is clicked on the homepage it doesn't render back the "welcome to soul bench" component -> now it does; 
    - this means you press on a public convo and press logo -> home
    - this means mid-convo making and press logo -> home
- Buddy's name is populated on the my bench card
```
 buddy: user.buddy.username, 
```
![Screenshot 2024-03-25 at 1 18 00 AM](https://github.com/ae-andre/insights-bench/assets/56553374/df7eecff-f64b-496d-8bd2-7bb2e59291bd)
![Screenshot 2024-03-25 at 1 18 09 AM](https://github.com/ae-andre/insights-bench/assets/56553374/5448cbed-27e9-4ce8-bdcf-41346e27acb4)
- When user clicks on add new conversation and then presses on an existing public conversation it stays on the conversation creation form and doesn't go to the conversation (BUG FIXED)
```
setIsStartingPublicConversation(false)
```
is added to the `handleConversationClick` function so that it doesn't keep conditionally the conversation form
- When user submits PRIVATE conversation, it renders immediately, primarily changed if there isn't conversationID then it refetches:

```
  useEffect(() => {
    if (!conversationId) {
      refetchUser();
      refetchConversation;
    }
  }, [conversationId, refetchUser, refetchConversation]);
```
- Toast added to private conversation form
   - If over 500 for details and over 50 for title
- `required` added to choosing of what to talk about and also for all fields in private confirmation form
- No buddy flow - WAS just rendering the form again, NOW renders the modal:
![Screenshot 2024-03-25 at 3 13 09 AM](https://github.com/ae-andre/insights-bench/assets/56553374/67253475-91ef-408f-a808-2ff77e67dbcc)
- When private conversation is rendered, buddy name is displayed in title card
![Screenshot 2024-03-25 at 3 44 18 AM](https://github.com/ae-andre/insights-bench/assets/56553374/3713cee4-250c-440d-ac3b-822b89d62e08)
- Different color for comments
![Screenshot 2024-03-25 at 4 20 22 AM](https://github.com/ae-andre/insights-bench/assets/56553374/a70bc0dd-0654-4a65-8485-ab2ca06acebe)
